### PR TITLE
Translate /config/locales/en.yml in cs

### DIFF
--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -173,6 +173,7 @@ cs:
         enabled: Vždy zapnuto
         optional: Volitelný
     rooms:
+      timeout: "Protože %{server} Požadavku vypršel časový limit, informace o stavu a účastnících nemusí být přesná"
       title: Místnosti
       table:
         ended: "Ukončeno: %{session}"
@@ -491,7 +492,7 @@ cs:
       visibility: Viditelnost
       formats: Formáty
     visibility:
-      public: Veřejný
+      public: Veřejné
       unlisted: Neveřejné
     format:
       notes: Poznámky


### PR DESCRIPTION
translation completed for the source file '/config/locales/en.yml'
on the 'cs' language.